### PR TITLE
Separate stdout and stderr logs

### DIFF
--- a/chainlink/__init__.py
+++ b/chainlink/__init__.py
@@ -81,7 +81,10 @@ class Chainlink:
     result = {
       "data": self.client.api.inspect_container(container.id)["State"],
       "killed": killed,
-      "logs": container.logs(timestamps=True),
+      "logs": {
+        "stdout": container.logs(stderr=False, timestamps=True),
+        "stderr": container.logs(stdout=False, timestamps=True)
+      }
     }
     result["success"] = (not killed) and (result["data"]["ExitCode"] == 0)
     container.remove()

--- a/tests/integration/basic.py
+++ b/tests/integration/basic.py
@@ -28,5 +28,5 @@ class TestBasicChaining(unittest.TestCase):
     chain = Chainlink(stages)
     results = chain.run(env)
     
-    self.assertTrue("TEST=testing" in results[0]["logs"].decode("utf-8"))
+    self.assertTrue("TEST=testing" in results[0]["logs"]["stdout"].decode("utf-8"))
     self.assertEqual(results[1]["data"]["ExitCode"], 0)


### PR DESCRIPTION
As title, this pull request replaces the `logs` key in the result with a dictionary containing the `stdout` and `stderr` logs separately.

Tests have been updated to reflect changes.