### PR TITLE
Make environment optional during run

### DIFF
--- a/chainlink/__init__.py
+++ b/chainlink/__init__.py
@@ -25,7 +25,7 @@ class Chainlink:
     self._pull_status = {}
     self._pull_images()
 
-  def run(self, environ):
+  def run(self, environ={}):
     results = []
     with tempfile.TemporaryDirectory(dir=self.workdir) as mount:
       logger.info("using {} for temporary job directory".format(mount))


### PR DESCRIPTION
As the documentation mentions, it usually makes sense to have the base environment of a run be empty during a run. This PR makes the base environment an empty dictionary and optional.