### PR TITLE
Replace capabilities with privileged flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ The `Chainlink` constructor takes a list of `stages` to chain and a `workdir` in
 ```python
 # a single-stage specification
 stages = [{
-  # container capabilities (optional, defaults to [])
-  "capabilities": ["NET_ADMIN", "SYS_ADMIN"],
   # container entrypoint (optional, defaults to image entrypoint)
   "entrypoint": ["ip", "link", "set", "lo", "up"],
   # container hostname (optional, defaults to 'container')
@@ -37,6 +35,8 @@ stages = [{
   "memory": "2g",
   # whether to allow networking capabilities (optional, defaults to True)
   "networking": True,
+  # whether to switch on privileged mode (optional, defaults to False)
+  "privileged": True,
   # the number of seconds until the container is killed (optional, defaults to 30)
   "timeout": 30,
   # container environment additions/overrides (optional, defaults to none)

--- a/chainlink/__init__.py
+++ b/chainlink/__init__.py
@@ -88,7 +88,7 @@ class Chainlink:
       "mem_limit": stage.get("memory", "2g"),
       "memswap_limit": stage.get("memory", "2g"), # same as memory, so no swap
       "network_disabled": not stage.get("networking", True),
-      "cap_add": stage.get("capabilities", []),
+      "privileged": stage.get("privileged", False),
       "volumes": volumes,
       "tty": True
     }

--- a/tests/integration/privileged_test.py
+++ b/tests/integration/privileged_test.py
@@ -6,16 +6,16 @@ stages = [
   {
     "image": "ubuntu:14.04",
     "entrypoint": ["unshare", "--mount", "echo", "dumb"],
-    "capabilities": ["SYS_ADMIN"]
+    "privileged": True
   },
   {
     "image": "ubuntu:14.04",
     "entrypoint": ["ip", "link", "set", "lo", "up"],
-    "capabilities": ["NET_ADMIN"]
+    "privileged": True
   }
 ]
 
-class TestCapAdd(unittest.TestCase):
+class TestPrivileged(unittest.TestCase):
 
   def test_basic_chain(self):
     chain = Chainlink(stages)


### PR DESCRIPTION
Replace --cap-add with --privileged can fix the mounting problem in unshare.
And it seems neater to do so than manipulating raw linux capabilities.

Related PR: https://github.com/illinois-cs241/docker-tools/pull/24