### PR TITLE
Expose async interface for chainlink.run

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ Note that all images needed to run the specified stages are pulled in parallel d
 #### Run
 
 ```
-run(self, environ={}):
+def run(self, environ={})
+async def run_async(self, environ={})
 ```
 
 The `Chainlink` run function takes a base environment (`environ`) and executes each container specified by `stages` during construction in sequence. If a stage fails, then no subsequent stages will be run.
@@ -85,6 +86,8 @@ The run function returns a list of object, an example of which is annotated belo
 ```
 
 Note that the returned list will have the same number of elements as there are stages, with element corresponding to the stage with the same index.
+
+`run_async` is an async version of `run`.
 
 ### Cross-Stage Communication
 

--- a/chainlink/__init__.py
+++ b/chainlink/__init__.py
@@ -121,7 +121,7 @@ class Chainlink:
         try:
             await asyncio.wait_for(
                 event_loop.run_in_executor(self._executor, container.wait),
-                timeout=timeout
+                timeout=timeout,
             )
         except asyncio.TimeoutError:
             logger.error("killing container after {} seconds".format(timeout))

--- a/tests/integration/basic.py
+++ b/tests/integration/basic.py
@@ -13,8 +13,8 @@ stages_1 = [
 
 stages_2 = [
     {
-        "image": "no-such-image:1000000.001.3.1415926535",
-        "entrypoint": ["ain't", "no", "gonna", "run"],
+        "image": "no-such-image:3.1415926535",
+        "entrypoint": ["env"],
     }
 ]
 

--- a/tests/integration/basic.py
+++ b/tests/integration/basic.py
@@ -2,7 +2,7 @@ import unittest
 
 from chainlink import Chainlink
 
-stages = [
+stages_1 = [
     {
         "image": "alpine:3.5",
         "entrypoint": ["env"],
@@ -10,15 +10,27 @@ stages = [
     },
     {"image": "alpine:3.5", "entrypoint": ["sleep", "2"]},
 ]
+
+stages_2 = [
+    {
+        "image": "no-such-image:1000000.001.3.1415926535",
+        "entrypoint": ["ain't", "no", "gonna", "run"],
+    }
+]
+
 env = {"TEST": "testing", "SEMESTER": "sp18", "ASSIGNMENT": "mp1"}
 
 
 class TestBasicChaining(unittest.TestCase):
     def test_basic_chain(self):
-        chain = Chainlink(stages)
+        chain = Chainlink(stages_1)
         results = chain.run(env)
 
         self.assertFalse(results[0]["killed"])
         self.assertTrue("TEST=testing" in results[0]["logs"]["stdout"].decode("utf-8"))
         self.assertFalse(results[0]["killed"])
         self.assertEqual(results[1]["data"]["ExitCode"], 0)
+
+    def test_no_such_image(self):
+        with self.assertRaises(Exception):
+            Chainlink(stages_2)

--- a/tests/integration/basic.py
+++ b/tests/integration/basic.py
@@ -11,12 +11,7 @@ stages_1 = [
     {"image": "alpine:3.5", "entrypoint": ["sleep", "2"]},
 ]
 
-stages_2 = [
-    {
-        "image": "no-such-image:3.1415926535",
-        "entrypoint": ["env"],
-    }
-]
+stages_2 = [{"image": "no-such-image:3.1415926535", "entrypoint": ["env"]}]
 
 env = {"TEST": "testing", "SEMESTER": "sp18", "ASSIGNMENT": "mp1"}
 


### PR DESCRIPTION
Hi, I added an async version for `chainlink.run` -> `chainlink.run_async`.
It'll be useful for worker since the `websockets` package in broadway-grader only supports asyncio interface.