### PR TITLE
Add cpuset_cpus stage parameter and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ stages = [{
   "image": "alpine:3.5",
   # memory cap (optional, defaults to 2GB)
   "memory": "2g",
+  # set of cpus to use, e.g. 0-3 for the first four or 0,2 for the first and third (optional, defaults to all)
+  "cpuset_cpus": "0-7",
   # whether to allow networking capabilities (optional, defaults to True)
   "networking": True,
   # whether to switch on privileged mode (optional, defaults to False)

--- a/chainlink/__init__.py
+++ b/chainlink/__init__.py
@@ -85,6 +85,7 @@ class Chainlink:
         # TODO find a way to set disk limit?
         options = {
             "cpu_period": 100000,  # microseconds
+            "cpuset_cpus": stage.get("cpuset_cpus", None),
             "detach": True,
             "entrypoint": stage.get("entrypoint", None),
             "environment": environ,

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     name="chainlink",  # Required
     # Versions should comply with PEP 440:
     # https://www.python.org/dev/peps/pep-0440/
-    version="0.0.6",  # Required
+    version="0.0.7",  # Required
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:
     # https://packaging.python.org/specifications/core-metadata/#summary


### PR DESCRIPTION
- Add `cpuset_cpus` stage parameter as described in the [docker cli docs](https://docs.docker.com/config/containers/resource_constraints/#configure-the-default-cfs-scheduler) and the [docker python library docs](https://docker-py.readthedocs.io/en/stable/containers.html#docker.models.containers.ContainerCollection.run)
- Update the README with usage information
- Bump the patch version 0.0.6 -> 0.0.7